### PR TITLE
chore(OPS-265): update deprecated cache action

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -21,10 +21,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Create LFS file list
-        run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+        run: git lfs ls-files -l | cut -d ' ' -f1 | sort > .lfs-assets-id
 
       - name: Restore LFS cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: lfs-cache
         with:
           path: .git/lfs
@@ -34,7 +34,7 @@ jobs:
         run: git lfs pull
 
       - name: Go cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           # In order:
           # * Module download cache


### PR DESCRIPTION
Changes:

Maybe unnecessary if we don't really plan to add changes but action/cache being deprecated we'd better have the CI in a workable state.
This bumps action cache and other deprecated actions spotted while doing so